### PR TITLE
Prefer domain specific email adresses

### DIFF
--- a/en/1dojoCreation.md
+++ b/en/1dojoCreation.md
@@ -13,7 +13,7 @@
 * Find a domain name (e.g. coderdojogeekville.org)
 * Buy said domain name
 * Buy suitable hosting
-* Create a mail account for your CoderDojo (e.g. : `geekvilleCoderdojo@gmail.com`)
+* Create a mail account for your CoderDojo (e.g. : `contact@coderdojogeekville.org`)
 * Create a blog on the domain
 * Create a Facebook page
 * Create a twitter account


### PR DESCRIPTION
Hi there,

I am the chairman for the CoderDojo Foundation in The Netherlands and we support almost 70 dojo's at the moment. When dealing with internet presence we always stress the importance of using an email address connected to your domain name.

Simply for security reasons! This month is safety awareness month at CoderDojo HQ if i'm not mistaken. So to give a little more background on this train of thought; if you are using a generic email provider (`gmail`, `hotmail`, `yahoo`, etc.) it's very easy for someone else to create a similar emailaddress (in this case e.g. `coderdojogeekville@gmail.com`) and act as if he / she belongs to the dojo.

When the dojo uses an emailaddress with the dojo's domain name, the recipient can be more assured they are dealing with the actual dojo instead of an imposter!

I will raise this in the Global Slack as well to see if maybe this is interesting to give more attention as well.

As always, BE COOL!